### PR TITLE
Remove "to" prop from Media component

### DIFF
--- a/src/web/theme/modules/ProductItem/ProductItem.js
+++ b/src/web/theme/modules/ProductItem/ProductItem.js
@@ -7,7 +7,6 @@ import Media from "theme/ui/organisms/Media";
 const ProductItem = ({ name, prices, sku, imageUrl }) => {
   return (
     <Media
-      to={`product/${sku}`}
       media={<img src={createMediaUrlFromPath(imageUrl)} alt={name} />}
       renderDetails={() => (
         <Fragment>


### PR DESCRIPTION
The Media component [doesn't seem to have a `to` prop](https://github.com/front-commerce/front-commerce-lite/blob/master/src/web/theme/ui/organisms/Media/Media.js#L18-L21) so it's not getting used at the moment.