### PR TITLE
Implement a fake shop with fake data

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,6 @@
 # Uncomment the line below to remove Front-Commerce
 # demo schema from this GraphQL schema
 # FEATURE_DEMO_REMOTE_SCHEMA_STITCHING_DISABLE=true
+
+# Uncomment the line below to enable a fake local shop
+# FEATURE_FAKE_LOCAL_SHOP_ENABLE=true

--- a/.env
+++ b/.env
@@ -1,0 +1,11 @@
+# This file allows you to customize the application
+# Upon change, you must restart or reload the
+# application.
+
+## Feature Flags
+# The options below are features that you can enable
+# or disable to see how they impact the application.
+
+# Uncomment the line below to remove Front-Commerce
+# demo schema from this GraphQL schema
+# FEATURE_DEMO_REMOTE_SCHEMA_STITCHING_DISABLE=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -4561,7 +4561,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -4574,7 +4574,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -5878,6 +5878,11 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -6298,8 +6303,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6320,14 +6324,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6342,20 +6344,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6472,8 +6471,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6485,7 +6483,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6500,7 +6497,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6508,14 +6504,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6534,7 +6528,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6615,8 +6608,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6628,7 +6620,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6714,8 +6705,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6751,7 +6741,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6771,7 +6760,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6815,14 +6803,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7326,7 +7312,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -7341,7 +7327,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -10083,7 +10069,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -13655,7 +13641,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "body-parser": "1.18.3",
     "cors": "2.8.5",
     "express": "4.16.4",
+    "faker": "^4.1.0",
     "fetch-cookie": "0.7.2",
     "file-loader": "1.1.11",
     "graphql": "0.13.2",

--- a/src/server/express/withGraphQLApi.js
+++ b/src/server/express/withGraphQLApi.js
@@ -33,6 +33,9 @@ export default async modules => {
 };
 
 async function remoteFrontCommerceMagento2DemoSchema() {
+  if (process.env.FEATURE_DEMO_REMOTE_SCHEMA_STITCHING_DISABLE) {
+    return;
+  }
   const link = new HttpLink({
     uri: "https://demo.front-commerce.com/graphql",
     // to persist session between refreshes you can inject a custom cookie jar

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,7 +1,6 @@
 import express from "express";
 import cors from "cors";
 import withGraphQLApi from "./express/withGraphQLApi";
-import modules from "./modules.js";
 
 require("dotenv").config({ silent: true });
 
@@ -18,7 +17,7 @@ async function start() {
       origin: "*"
     })
   );
-  app.use(await withGraphQLApi(modules));
+  app.use(await withGraphQLApi(require("./modules").default));
 
   const server = app.listen(config.port, config.host, undefined, () => {
     /* eslint-disable no-console */

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -3,6 +3,8 @@ import cors from "cors";
 import withGraphQLApi from "./express/withGraphQLApi";
 import modules from "./modules.js";
 
+require("dotenv").config({ silent: true });
+
 const config = {
   host: process.env.FRONT_COMMERCE_HOST || "0.0.0.0",
   port: process.env.FRONT_COMMERCE_PORT || process.env.VIRTUAL_PORT || 4000

--- a/src/server/modules.js
+++ b/src/server/modules.js
@@ -1,4 +1,5 @@
 import StoreInformation from "./modules/store-information";
+import FakeShop from "./modules/fake-shop";
 
 export default [
   // In a real Front-Commerce application you could load core modules
@@ -8,5 +9,6 @@ export default [
   // the project that match your needs and run away from a monolithic
   // architecture when it is not relevant
 
-  StoreInformation
-];
+  StoreInformation,
+  process.env.FEATURE_FAKE_LOCAL_SHOP_ENABLE ? FakeShop : undefined
+].filter(Boolean); // only keep the enabled ones

--- a/src/server/modules/fake-shop/index.js
+++ b/src/server/modules/fake-shop/index.js
@@ -1,0 +1,9 @@
+import typeDefs from "./schema.gql";
+import resolvers from "./resolvers";
+
+export default {
+  namespace: "FakeShop",
+  context: {},
+  typeDefs,
+  resolvers
+};

--- a/src/server/modules/fake-shop/resolvers.js
+++ b/src/server/modules/fake-shop/resolvers.js
@@ -5,11 +5,15 @@ let cart = [];
 
 const makeRandomProduct = () => ({
   sku: faker.helpers.slugify(faker.commerce.product()),
-  name: faker.commerce.productName,
+  name: faker.commerce.productName(),
   description: faker.lorem.paragraphs(3, "<br /><br />"),
   imageUrl: faker.image.technics(400, 400),
   prices: { finalPrice: faker.commerce.price() }
 });
+
+const catalog = [...new Array(faker.random.number({ min: 7, max: 60 }))].map(
+  makeRandomProduct
+);
 
 const resolveSomeday = value =>
   new Promise(resolve =>
@@ -24,16 +28,16 @@ export default {
     category: () => ({
       name: "My Category",
       layer: ({ params: { size } }) => ({
-        products: [...new Array(size)].map(makeRandomProduct)
+        products: [...catalog].slice(0, size)
       })
     }),
-    product: makeRandomProduct,
+    product: (_, { sku }) => catalog.find(product => product.sku === sku),
     cart: () => cart
   },
 
   Mutation: {
-    addItemToCart: () => {
-      cart = [...cart, makeRandomProduct()];
+    addItemToCart: (_, { sku }) => {
+      cart = [...cart, catalog.find(product => product.sku === sku)];
       return resolveSomeday({
         success: true,
         cart

--- a/src/server/modules/fake-shop/resolvers.js
+++ b/src/server/modules/fake-shop/resolvers.js
@@ -1,0 +1,93 @@
+import faker from "faker";
+
+const currency = "EUR";
+let cart = [];
+
+const makeRandomProduct = () => ({
+  sku: faker.helpers.slugify(faker.commerce.product()),
+  name: faker.commerce.productName,
+  description: faker.lorem.paragraphs(3, "<br /><br />"),
+  imageUrl: faker.image.technics(400, 400),
+  prices: { finalPrice: faker.commerce.price() }
+});
+
+const resolveSomeday = value =>
+  new Promise(resolve =>
+    setTimeout(
+      () => resolve(value),
+      faker.random.number({ min: 100, max: 2000 })
+    )
+  );
+
+export default {
+  Query: {
+    category: () => ({
+      name: "My Category",
+      layer: ({ params: { size } }) => ({
+        products: [...new Array(size)].map(makeRandomProduct)
+      })
+    }),
+    product: makeRandomProduct,
+    cart: () => cart
+  },
+
+  Mutation: {
+    addItemToCart: () => {
+      cart = [...cart, makeRandomProduct()];
+      return resolveSomeday({
+        success: true,
+        cart
+      });
+    },
+    removeItemFromCart: (_, { item_id }) => {
+      cart.splice(item_id - 1, 1);
+      cart = [...cart];
+      return resolveSomeday({
+        success: true,
+        cart
+      });
+    }
+  },
+
+  Cart: {
+    id: () => 42,
+    items_qty: cart => cart.length,
+    items: cart => cart,
+    totals: cart =>
+      cart
+        .map(product => parseFloat(product.prices.finalPrice))
+        .reduce((total, value) => total + value, 0)
+  },
+
+  CartItem: {
+    item_id: item => cart.indexOf(item) + 1,
+    qty: () => 1,
+    product: item => item,
+    priceInfo: item => item.prices.finalPrice
+  },
+
+  CartItemPriceInfo: {
+    rowTotalInclTax: amount => ({
+      includeTax: true,
+      value: { amount: amount, currency }
+    })
+  },
+
+  CartTotals: {
+    subtotalInclTax: amount => ({
+      includeTax: true,
+      value: { amount: amount, currency }
+    })
+  },
+
+  BothInclAndExclTaxesPrice: {
+    priceInclTax: amount => ({
+      includeTax: true,
+      value: { amount, currency }
+    }),
+    priceExclTax: amount => ({
+      includeTax: false,
+      value: { amount, currency }
+    })
+  }
+};

--- a/src/server/modules/fake-shop/schema.gql
+++ b/src/server/modules/fake-shop/schema.gql
@@ -1,0 +1,81 @@
+type Query {
+  category(id: Int!): Category
+  product(sku: String!): Product
+  cart: Cart
+}
+
+type Mutation {
+  addItemToCart(sku: String!): CartPayload
+  removeItemFromCart(item_id: Int!): CartPayload
+}
+
+type CartPayload {
+  success: Boolean
+  errorMessage: String
+  cart: Cart
+}
+
+type Cart {
+  id: Int
+  items_qty: Int
+  items: [CartItem]
+  totals: CartTotals
+}
+
+type CartItem {
+  name: String
+  qty: Int
+  item_id: Int
+  sku: String
+  product: Product
+  priceInfo: CartItemPriceInfo
+}
+
+type CartItemPriceInfo {
+  rowTotalInclTax: Price
+}
+
+type CartTotals {
+  subtotalInclTax: Price
+}
+
+type Category {
+  name: String
+  layer(params: QueryInput!): Layer
+}
+
+input QueryInput {
+  size: Int!
+  from: Int!
+}
+
+type Layer {
+  products: [Product]
+}
+
+type Product {
+  sku: String
+  name: String
+  description: String
+  imageUrl: String
+  prices: ProductPrices
+}
+
+type ProductPrices {
+  finalPrice: BothInclAndExclTaxesPrice
+}
+
+type BothInclAndExclTaxesPrice {
+  priceInclTax: Price
+  priceExclTax: Price
+}
+
+type Price {
+  value: Money
+  includeTax: Boolean
+}
+
+type Money {
+  amount: Float
+  currency: String
+}

--- a/src/web/theme/modules/Cart/CartFragment.gql
+++ b/src/web/theme/modules/Cart/CartFragment.gql
@@ -11,14 +11,5 @@ fragment CartFragment on Cart {
     subtotalInclTax {
       ...PriceFragment
     }
-    totalInclTax {
-      ...PriceFragment
-    }
-    totalExclTax {
-      ...PriceFragment
-    }
-    tax {
-      ...PriceFragment
-    }
   }
 }


### PR DESCRIPTION
This PR introduces an alternative implementation for the shop with faked data and a naive cart implementation. It is behind a feature flag too.
It allowed extracting the minimal schema used by the UI so far.

The goal here was to illustrate how to create another backend implementation without changing the frontend.

The next step (in an upcoming PR) is to extract types and an interface from this schema, to ensure that all future implementations satisfy this contract.